### PR TITLE
test(envFile): ensure env vars with spaces in values parse correctly

### DIFF
--- a/test/envFile.spec.ts
+++ b/test/envFile.spec.ts
@@ -44,4 +44,20 @@ describe('Environment file parser', () => {
 
     expect(parseEnvFile('.env.mock', false)).toEqual(expectedEnv);
   });
+
+  it('should read the value of env vars correctly when it contains spaces', () => {
+    const fileContent = [
+      `KEY${KEY_VALUE_SEPARATOR}"value with spaces"`,
+      `DATABASE${KEY_VALUE_SEPARATOR}'prod environment'`,
+    ].join('\n');
+
+    const expectedEnv = {
+      KEY: 'value with spaces',
+      DATABASE: 'prod environment',
+    };
+
+    readFileSyncSpy.mockReturnValue(fileContent);
+
+    expect(parseEnvFile('.env.mock', false)).toEqual(expectedEnv);
+  });
 });


### PR DESCRIPTION
Refs. #12 