### PR TITLE
test(envFile): ensure parser does not allow an invalid env var separator

### DIFF
--- a/test/envFile.spec.ts
+++ b/test/envFile.spec.ts
@@ -78,4 +78,19 @@ describe('Environment file parser', () => {
 
     expect(parseEnvFile('.env.mock', false)).toEqual(expectedEnv);
   });
+
+  it('should throw an error when key-value pairs contain an invalid separator', () => {
+    const fileContent = [
+      `KEY${KEY_VALUE_SEPARATOR}value`,
+      'DATABASE:value',
+    ].join('\n');
+
+    readFileSyncSpy.mockReturnValue(fileContent);
+
+    expect(() => {
+      parseEnvFile('.env.mock', false);
+    }).toThrow(
+      `Error parsing line 2 of ".env.mock": Invalid variable separator, expected "NAME${KEY_VALUE_SEPARATOR}VALUE" format`,
+    );
+  });
 });


### PR DESCRIPTION
Refs. #12 