### PR TITLE
test(envFile): ensure long values of env vars are parsed correctly

### DIFF
--- a/test/envFile.spec.ts
+++ b/test/envFile.spec.ts
@@ -119,4 +119,17 @@ describe('Environment file parser', () => {
 
     expect(parseEnvFile('.env.mock', false)).toEqual(expectedEnv);
   });
+
+  it('should read the value of env vars correctly when it is long', () => {
+    const fileContent =
+      'LONG_KEY=longvaluehere1234567890abcdefghijklmnopqrstuvwx';
+
+    const expectedEnv = {
+      LONG_KEY: 'longvaluehere1234567890abcdefghijklmnopqrstuvwx',
+    };
+
+    readFileSyncSpy.mockReturnValue(fileContent);
+
+    expect(parseEnvFile('.env.mock', false)).toEqual(expectedEnv);
+  });
 });


### PR DESCRIPTION
Refs. #12 