### PR TITLE
test(envFile): ensure double quotes are parsed as value when unclosed

### DIFF
--- a/test/envFile.spec.ts
+++ b/test/envFile.spec.ts
@@ -244,4 +244,20 @@ describe('Environment file parser', () => {
 
     expect(parseEnvFile('.env.mock', false)).toEqual(expectedEnv);
   });
+
+  it('should read any double quote as part of the env var value when the value does not ends with a double quote', () => {
+    const fileContent = [
+      `KEY${KEY_VALUE_SEPARATOR}"value with spaces`,
+      `DATABASE${KEY_VALUE_SEPARATOR}"path to"/data`,
+    ].join('\n');
+
+    const expectedEnv = {
+      KEY: '"value with spaces',
+      DATABASE: '"path to"/data',
+    };
+
+    readFileSyncSpy.mockReturnValue(fileContent);
+
+    expect(parseEnvFile('.env.mock', false)).toEqual(expectedEnv);
+  });
 });


### PR DESCRIPTION
Refs. #12 