### PR TITLE
test(cli): ensure the command target is part of the input for parsing

### DIFF
--- a/test/cli/parser.spec.ts
+++ b/test/cli/parser.spec.ts
@@ -1,0 +1,45 @@
+import { parse } from '@/cli/parser';
+
+const schema = {
+  flagA: {
+    description: 'Option A',
+    longFlag: 'flagA',
+    shortFlag: 'fa',
+    type: {
+      isArray: false,
+      primitiveType: 'boolean',
+    },
+  },
+  flagB: {
+    description: 'Option B',
+    longFlag: 'flagB',
+    shortFlag: 'fb',
+    type: {
+      isArray: true,
+      primitiveType: 'string',
+    },
+  },
+  flagC: {
+    description: 'Option C',
+    longFlag: 'flagC',
+    type: {
+      isArray: false,
+      primitiveType: 'string',
+    },
+  },
+  help: {
+    description: 'Help option',
+    longFlag: 'help',
+    shortFlag: 'h',
+  },
+} as const;
+
+describe('parse', () => {
+  it('should throw an error when the input does not contain the target command', () => {
+    const input: string[] = [];
+
+    expect(() => parse(input, schema)).toThrow(
+      'Error parsing CLI input: Missing target command',
+    );
+  });
+});


### PR DESCRIPTION
Completes task 1 from #73 