### PR TITLE
test(cli): ensure target command args are parsed as empty list if absent

### DIFF
--- a/test/cli/parser.spec.ts
+++ b/test/cli/parser.spec.ts
@@ -42,4 +42,10 @@ describe('parse', () => {
       'Error parsing CLI input: Missing target command',
     );
   });
+
+  it('should return an empty list of target command args when the input contains the target command without any args', () => {
+    const input = ['command-target'];
+
+    expect(parse(input, schema).command.args).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Completes task 2 from #73 