### PR TITLE
test(cli): ensure input options is parsed as undefined if missing

### DIFF
--- a/test/cli/parser.spec.ts
+++ b/test/cli/parser.spec.ts
@@ -64,4 +64,10 @@ describe('parse', () => {
 
     expect(parse(input, schema).command.args).toEqual(expectedCommandArgs);
   });
+
+  it('should not return any option when the input does not contain any option', () => {
+    const input = ['target-command'];
+
+    expect(parse(input, schema).options).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Completes task 4 from #73 