### PR TITLE
test(cli): ensure the correct option is parsed if one option in input

### DIFF
--- a/test/cli/parser.spec.ts
+++ b/test/cli/parser.spec.ts
@@ -70,4 +70,13 @@ describe('parse', () => {
 
     expect(parse(input, schema).options).toBeUndefined();
   });
+
+  it('should return the correct option when the input contains only one option', () => {
+    const input = ['--flagA', 'command-target'];
+    const expectedOptions = {
+      flagA: true,
+    };
+
+    expect(parse(input, schema).options).toEqual(expectedOptions);
+  });
 });


### PR DESCRIPTION
Completes task 5 from #73 