### PR TITLE
fix(cli): replace magic string in parsing tests

### DIFF
--- a/test/cli/parser.spec.ts
+++ b/test/cli/parser.spec.ts
@@ -243,7 +243,10 @@ describe('parse', () => {
 
   it('should treat the combination of a flag and its value as a unique flag when the flag-value separator is missing', () => {
     const unseparatedOption = 'flagCvalue';
-    const input = [`${CLI_FLAG_LONG_PREFIX}flagCvalue`, 'command-target'];
+    const input = [
+      `${CLI_FLAG_LONG_PREFIX}${unseparatedOption}`,
+      'command-target',
+    ];
 
     expect(() => parse(input, schema)).toThrow(
       `Error parsing CLI input: Unknown option "${unseparatedOption}"`,


### PR DESCRIPTION
Fixes #94 