### PR TITLE
test(cli): ensure required value separators are necessary in parsing

### DIFF
--- a/test/cli/parser.spec.ts
+++ b/test/cli/parser.spec.ts
@@ -280,4 +280,16 @@ describe('parse', () => {
 
     expect(parse(input, schema).options).toEqual(expectedOptions);
   });
+
+  it('should treat the values of multi-valued options as single value when those values are not separated', () => {
+    const input = [
+      `${CLI_FLAG_LONG_PREFIX}flagB${CLI_FLAG_VALUE_SEPARATOR}${['value1', 'value2value3', 'value4'].join(CLI_OPTION_VALUES_SEPARATOR)}`,
+      'command-target',
+    ];
+    const expectedOptions = {
+      flagB: ['value1', 'value2value3', 'value4'],
+    };
+
+    expect(parse(input, schema).options).toEqual(expectedOptions);
+  });
 });


### PR DESCRIPTION
Completes task 19 from #73 