### PR TITLE
test(cli): ensure false is a valid value for a boolean option in parsing

### DIFF
--- a/test/cli/parser.spec.ts
+++ b/test/cli/parser.spec.ts
@@ -326,4 +326,16 @@ describe('parse', () => {
     expect(expectedOptions).toHaveProperty('flagA', true);
     expect(typeof expectedOptions!.flagA).toBe('boolean');
   });
+
+  it('should accept "false" as an option value when the option has a boolean type', () => {
+    const input = [
+      `${CLI_FLAG_LONG_PREFIX}flagA${CLI_FLAG_VALUE_SEPARATOR}false`,
+      'command-target',
+    ];
+
+    const { options: expectedOptions } = parse(input, schema);
+
+    expect(expectedOptions).toHaveProperty('flagA', false);
+    expect(typeof expectedOptions!.flagA).toBe('boolean');
+  });
 });


### PR DESCRIPTION
Completes task 22 from #73 