### PR TITLE
test(cli): ensure only boolean value allowed for bool options in parsing

### DIFF
--- a/test/cli/parser.spec.ts
+++ b/test/cli/parser.spec.ts
@@ -347,4 +347,16 @@ describe('parse', () => {
     expect(expectedOptions).toHaveProperty('flagA', true);
     expect(typeof expectedOptions!.flagA).toBe('boolean');
   });
+
+  it('should throw an error when an invalid value is provided to a boolean option', () => {
+    const invalidBoolFlag = 'flagA';
+    const input = [
+      `${CLI_FLAG_LONG_PREFIX}${invalidBoolFlag}${CLI_FLAG_VALUE_SEPARATOR}value`,
+      'command-target',
+    ];
+
+    expect(() => parse(input, schema)).toThrow(
+      `Error parsing CLI input: Invalid value for boolean option "${invalidBoolFlag}"`,
+    );
+  });
 });


### PR DESCRIPTION
Completes task 24 from #73 