### PR TITLE
test(cli): ensure a string is a valid string option value during parsing

### DIFF
--- a/test/cli/parser.spec.ts
+++ b/test/cli/parser.spec.ts
@@ -370,4 +370,16 @@ describe('parse', () => {
       `Error parsing CLI input: Invalid value for boolean option "${invalidBoolFlag}"`,
     );
   });
+
+  it('should accept a string as an option value when the option has a "string" type', () => {
+    const input = [
+      `${CLI_FLAG_LONG_PREFIX}flagC${CLI_FLAG_VALUE_SEPARATOR}value`,
+      'command-target',
+    ];
+    const expectedOptions = {
+      flagC: 'value',
+    };
+
+    expect(parse(input, schema).options).toEqual(expectedOptions);
+  });
 });


### PR DESCRIPTION
Completes task 26 from #73 