### PR TITLE
test(cli): ensure true is parsed as value for untyped options

### DIFF
--- a/test/cli/parser.spec.ts
+++ b/test/cli/parser.spec.ts
@@ -396,4 +396,15 @@ describe('parse', () => {
 
     expect(parse(input, schema).options).toEqual(expectedOptions);
   });
+
+  // Untyped option handling
+
+  it('should return "true" as an option value when the option has no type', () => {
+    const input = [`${CLI_FLAG_LONG_PREFIX}flagD`, 'command-target'];
+    const expectedOptions = {
+      flagD: true,
+    };
+
+    expect(parse(input, schema).options).toEqual(expectedOptions);
+  });
 });


### PR DESCRIPTION
Completes task 28 from #73 