### PR TITLE
feat(cli): split param types of parser options into boolean and aliased

### DIFF
--- a/src/cli/parser/index.ts
+++ b/src/cli/parser/index.ts
@@ -4,7 +4,7 @@ import {
   CLI_FLAG_VALUE_SEPARATOR,
   CLI_OPTION_VALUES_SEPARATOR,
 } from '@/config';
-import type { Args, Options, OptionSpecType, SpecSchema } from './types';
+import type { Args, Options, OptionSpecParam, SpecSchema } from './types';
 
 function classifyArgs(args: string[]) {
   const options = [];
@@ -35,10 +35,10 @@ function parseBoolean(value: string, flag: string) {
 
 function parseValue(
   value: string | undefined,
-  type: OptionSpecType,
+  param: OptionSpecParam,
   flag: string,
 ) {
-  if (type === 'boolean') {
+  if (param === 'boolean') {
     if (!value) return true;
     return parseBoolean(value, flag);
   } else {
@@ -48,7 +48,7 @@ function parseValue(
       );
     }
 
-    if (type === 'string') return value;
+    if (param.type === 'string') return value;
     return value.split(CLI_OPTION_VALUES_SEPARATOR);
   }
 }
@@ -75,7 +75,7 @@ function parseOption(inputOption: string, schema: SpecSchema) {
 
   return {
     name,
-    value: param ? parseValue(value, param.type, flag) : true,
+    value: param ? parseValue(value, param, flag) : true,
   };
 }
 

--- a/src/cli/parser/types.ts
+++ b/src/cli/parser/types.ts
@@ -1,9 +1,11 @@
-export type OptionSpecType = 'boolean' | 'string' | 'stringArray';
+type BooleanType = 'boolean';
 
-type OptionSpecParam = {
-  type: OptionSpecType;
-  name?: string;
+type AliasedParam = {
+  alias: string;
+  type: 'string' | 'stringArray';
 };
+
+export type OptionSpecParam = BooleanType | AliasedParam;
 
 export interface OptionSpec {
   description: string;
@@ -14,14 +16,17 @@ export interface OptionSpec {
 
 export type SpecSchema = Record<string, OptionSpec>;
 
-type OptionSpecTypeMap = Record<OptionSpecType, unknown> & {
+type OptionSpecTypeMap = {
   boolean: boolean;
   string: string;
   stringArray: string[];
 };
 
-type OptionType<T extends OptionSpecParam | undefined> =
-  T extends OptionSpecParam ? OptionSpecTypeMap[T['type']] : boolean;
+type OptionType<T extends OptionSpecParam | undefined> = T extends BooleanType
+  ? OptionSpecTypeMap[T]
+  : T extends AliasedParam
+    ? OptionSpecTypeMap[T['type']]
+    : boolean;
 
 export type Options<T extends SpecSchema> = {
   [K in keyof T]?: OptionType<T[K]['param']>;

--- a/src/cli/schema.ts
+++ b/src/cli/schema.ts
@@ -5,8 +5,8 @@ export default {
     longFlag: 'file',
     shortFlag: 'f',
     param: {
+      alias: 'file',
       type: 'stringArray',
-      name: 'file',
     },
   },
   help: {
@@ -19,17 +19,13 @@ export default {
     description:
       'Prevents overwriting, ensuring repeated variables keep their initial value',
     longFlag: 'no-override',
-    param: {
-      type: 'boolean',
-    },
+    param: 'boolean',
   },
   verbose: {
     description:
       'Enables detailed console output during the loading of environment variables',
     longFlag: 'verbose',
     shortFlag: 'v',
-    param: {
-      type: 'boolean',
-    },
+    param: 'boolean',
   },
 } as const;

--- a/test/cli/parser.spec.ts
+++ b/test/cli/parser.spec.ts
@@ -11,15 +11,14 @@ const schema = {
     description: 'Option A',
     longFlag: 'flagA',
     shortFlag: 'fa',
-    param: {
-      type: 'boolean',
-    },
+    param: 'boolean',
   },
   flagB: {
     description: 'Option B',
     longFlag: 'flagB',
     shortFlag: 'fb',
     param: {
+      alias: 'strs',
       type: 'stringArray',
     },
   },
@@ -27,6 +26,7 @@ const schema = {
     description: 'Option C',
     longFlag: 'flagC',
     param: {
+      alias: 'str',
       type: 'string',
     },
   },


### PR DESCRIPTION
Refs. #131 