### PR TITLE
test(cli): ensure help message is built correctly for string options

### DIFF
--- a/test/cli/help.spec.ts
+++ b/test/cli/help.spec.ts
@@ -26,4 +26,25 @@ describe('buildHelp', () => {
 
     expect(buildHelp(inputSchema)).toBe(expectedMessage);
   });
+
+  it('should return the correct message when the options schema contains a string option', () => {
+    const inputSchema = {
+      flag: {
+        description: 'Option description',
+        longFlag: 'flag',
+        param: {
+          alias: 'value',
+          type: 'string',
+        },
+      },
+    } as const;
+    const expectedMessage = [
+      'Usage: envloadr [<options>] <target-command> [<args>]',
+      '\nOptions:',
+      '\t--flag=<value>',
+      '\t\tOption description',
+    ].join('\n');
+
+    expect(buildHelp(inputSchema)).toBe(expectedMessage);
+  });
 });


### PR DESCRIPTION
Completes task 4 from #134 