### PR TITLE
test(cli): ensure help msg for string options with short flag is valid

### DIFF
--- a/test/cli/help.spec.ts
+++ b/test/cli/help.spec.ts
@@ -67,5 +67,27 @@ describe('buildHelp', () => {
 
       expect(buildHelp(inputSchema)).toBe(expectedMessage);
     });
+
+    it('should return the correct message when the options schema contains a string option', () => {
+      const inputSchema = {
+        flag: {
+          description: 'Option description',
+          longFlag: 'flag',
+          shortFlag: 'f',
+          param: {
+            alias: 'value',
+            type: 'string',
+          },
+        },
+      } as const;
+      const expectedMessage = [
+        'Usage: envloadr [<options>] <target-command> [<args>]',
+        '\nOptions:',
+        '\t--flag=<value>, -f=<value>',
+        '\t\tOption description',
+      ].join('\n');
+
+      expect(buildHelp(inputSchema)).toBe(expectedMessage);
+    });
   });
 });


### PR DESCRIPTION
Completes task 5 from #134 