### PR TITLE
test(cli): ensure blank command target is not allowed during parsing

### DIFF
--- a/test/cli/parser.spec.ts
+++ b/test/cli/parser.spec.ts
@@ -70,6 +70,14 @@ describe('parse', () => {
     expect(parse(input, schema).command.args).toEqual(expectedCommandArgs);
   });
 
+  it('should throw an error when the target command is a blank string', () => {
+    const input: string[] = ['    '];
+
+    expect(() => parse(input, schema)).toThrow(
+      'Error parsing CLI input: Invalid target command',
+    );
+  });
+
   // Handling options
 
   it('should not return any option when the input does not contain any option', () => {


### PR DESCRIPTION
Completes task 1 from #151 