### PR TITLE
fix: prevents "publish" GitHub Actions workflow runs on forks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ permissions:
 
 jobs:
   publish-npm:
+    # prevents this action from running on forks
+    if: github.repository == 'patoale/envloadr'
+    
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Fixes #220 